### PR TITLE
Fix/login page

### DIFF
--- a/components/flow/LogInForm.vue
+++ b/components/flow/LogInForm.vue
@@ -35,12 +35,6 @@
         type="password"
         placeholder="Password"
       />
-      <b-form-invalid-feedback :state="passwordOk">
-        <p v-if="passwordRequirementsNotMet">
-          Your password must be at at least 8 characters long, and have at least
-          1 upper- and lower-case letter, 1 number, and 1 special character.
-        </p>
-      </b-form-invalid-feedback>
     </b-input-group>
 
     <b-button

--- a/components/flow/SignUpForm.vue
+++ b/components/flow/SignUpForm.vue
@@ -52,8 +52,7 @@
       />
       <b-form-invalid-feedback :state="passwordsOk">
         <p v-if="passwordRequirementsNotMet">
-          Your password must be at at least 8 characters long, and have at least
-          1 upper- and lower-case letter, 1 number, and 1 special character.
+          Your password must be at least 8 characters long.
         </p>
       </b-form-invalid-feedback>
     </b-input-group>

--- a/mixins/auth/password_form_mixin.js
+++ b/mixins/auth/password_form_mixin.js
@@ -6,9 +6,7 @@ export default {
   },
   computed: {
     passwordRequirementsNotMet() {
-      return !/^(?=.*[a-z])(?=.*[A-Z])(?=.*[0-9])(?=.*[!@#$%^&*])(?=.{8,})/.test(
-        this.password
-      )
+      return this.password.length !== 8
     },
     passwordOk() {
       if (!this.password) return null


### PR DESCRIPTION
Reduces password requirement to 8 characters, rather than 8 characters + 1 upper,lower char + 1 special char.

Removes information about the password requirement from the login page (will still stay red until 8 chars are met).