### PR TITLE
Fix environment API and remove unnecessary pill

### DIFF
--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -245,15 +245,6 @@ async function validateAndOpenBuilder (
     >
       <div class="grid gap-5 lg:grid-cols-[minmax(0,0.92fr)_minmax(520px,1fr)] lg:items-end">
         <div class="space-y-4">
-          <UBadge
-            color="primary"
-            variant="soft"
-            class="w-fit border border-lime-400/20 bg-lime-400/10 uppercase tracking-wide text-lime-300"
-          >
-            <UIcon name="i-lucide-zap" class="mr-1 size-4" />
-            Live data. Beautiful banners.
-          </UBadge>
-
           <div class="space-y-3">
             <h1 class="max-w-[820px] text-4xl font-bold leading-tight tracking-normal text-white">
               Build beautiful <span class="text-lime-300">live-updating</span> banners in seconds

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -17,7 +17,7 @@ export default defineNuxtConfig({
 
   runtimeConfig: {
     public: {
-      mcbannersApiBase: 'https://staging-api.mcbanners.com'
+      mcbannersApiBase: 'https://api.mcbanners.com'
     }
   },
 


### PR DESCRIPTION
This pull request makes a couple of small but important changes: it updates the API base URL to point to the production endpoint and removes a prominent "Live data" badge from the homepage UI.

- Configuration update:
  * Changed the `mcbannersApiBase` value in `nuxt.config.ts` from the staging API to the production API endpoint.

- UI adjustment:
  * Removed the "Live data. Beautiful banners." badge from the main page in `index.vue` to simplify the interface.